### PR TITLE
v2.0.0 to support vending multiple tokens and dashboard. BREAKING CHA…

### DIFF
--- a/gdk-config.json
+++ b/gdk-config.json
@@ -2,7 +2,7 @@
   "component" :{
     "aws.greengrass.labs.dashboard.Grafana": {
       "author": "AWS IoT Greengrass",
-      "version": "NEXT_PATCH",
+      "version": "2.0.0",
       "build": {
         "build_system": "zip"
       },

--- a/recipe.yaml
+++ b/recipe.yaml
@@ -1,7 +1,7 @@
 ---
 RecipeFormatVersion: '2020-01-25'
 ComponentName: aws.greengrass.labs.dashboard.Grafana
-ComponentVersion: '1.1.0'
+ComponentVersion: '2.0.0'
 ComponentDescription: 'A component that provisions and manages an Grafana instance.'
 ComponentPublisher: Amazon
 ComponentDependencies:


### PR DESCRIPTION
Version bump to 2.0.0.

BREAKING CHANGE: InfluxDB IPC token vending

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.